### PR TITLE
Release 0.5.4: hide abandon army for enlisted soldiers

### DIFF
--- a/Enlisted.csproj
+++ b/Enlisted.csproj
@@ -206,6 +206,7 @@
     <Compile Include="src\Mod.GameAdapters\Patches\CompanionCaptainBlockPatch.cs"/>
     <Compile Include="src\Mod.GameAdapters\Patches\GenericStateMenuPatch.cs"/>
     <Compile Include="src\Mod.GameAdapters\Patches\EndCaptivityCleanupPatch.cs"/>
+    <Compile Include="src\Mod.GameAdapters\Patches\AbandonArmyBlockPatch.cs"/>
   </ItemGroup>
   <ItemGroup>
     <Content Include="SubModule.xml"/>

--- a/Enlisted.csproj
+++ b/Enlisted.csproj
@@ -205,6 +205,7 @@
     <Compile Include="src\Mod.GameAdapters\Patches\PlayerIsAtSeaTagCrashFix.cs"/>
     <Compile Include="src\Mod.GameAdapters\Patches\CompanionCaptainBlockPatch.cs"/>
     <Compile Include="src\Mod.GameAdapters\Patches\GenericStateMenuPatch.cs"/>
+    <Compile Include="src\Mod.GameAdapters\Patches\EndCaptivityCleanupPatch.cs"/>
   </ItemGroup>
   <ItemGroup>
     <Content Include="SubModule.xml"/>

--- a/ModuleData/Enlisted/README.md
+++ b/ModuleData/Enlisted/README.md
@@ -209,6 +209,10 @@ Customize how formations are displayed per culture:
 ## Supported Cultures
 empire, aserai, sturgia, vlandia, khuzait, battania, nord, darshi
 
+## Enlisted settlement behavior
+- When enlisted and your lord/army reaches a town or castle, the enlisted menu remains active and now shows a Visit option. It only hides if you are already inside a native town/castle menu or an actual battle/siege is active.
+- Settlement encounters (peaceful entry) are allowed; only live battles or sieges block the enlisted menu.
+
 ## Notes
 
 - Changes to config files require restarting your campaign to take effect

--- a/ModuleData/Enlisted/README.md
+++ b/ModuleData/Enlisted/README.md
@@ -2,7 +2,7 @@
 
 JSON files controlling the Enlisted mod. Edit and restart campaign to apply changes.
 
-**Current Mod Version**: 0.5.3  
+**Current Mod Version**: 0.5.4  
 **Compatible Game Version**: 1.3.9
 
 ## Files

--- a/ModuleData/Enlisted/enlisted_config.json
+++ b/ModuleData/Enlisted/enlisted_config.json
@@ -6,7 +6,7 @@
         "compatible_game_versions": [
             "1.3.9"
         ],
-        "mod_version": "0.5.3"
+        "mod_version": "0.5.4"
     },
     "enlistment": {
         "tier_requirements": [

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.5.3.0")]
-[assembly: AssemblyFileVersion("0.5.3.0")]
+[assembly: AssemblyVersion("0.5.4.0")]
+[assembly: AssemblyFileVersion("0.5.4.0")]

--- a/SubModule.xml
+++ b/SubModule.xml
@@ -2,7 +2,7 @@
 <Module>
     <Name value="Enlisted"/>
     <Id value="Enlisted"/>
-    <Version value="v0.5.3"/>
+    <Version value="v0.5.4"/>
     <SingleplayerModule value="true"/>
     <Official value="false"/>
     <DependedModules>

--- a/docs/Features/Technical/encounter-safety.md
+++ b/docs/Features/Technical/encounter-safety.md
@@ -35,6 +35,7 @@ Prevents the player from triggering map encounters while enlisted by using the g
 - Player party hidden from map systems (UI and logical)
 - Smooth transitions between peace and battle states
 - Reliable cleanup when returning to normal campaign play
+- Hides native “Abandon army” menu option for enlisted players
 
 **Purpose:**
 Keep enlisted players from accidentally entering encounters that would break military service or cause pathfinding crashes, while ensuring they correctly join their Lord's battles without engine conflicts.
@@ -46,6 +47,7 @@ Keep enlisted players from accidentally entering encounters that would break mil
 - `src/Mod.GameAdapters/Patches/HidePartyNamePlatePatch.cs` - UI suppression
 - `src/Mod.GameAdapters/Patches/JoinEncounterAutoSelectPatch.cs` - Auto-joins lord's battle
 - `src/Mod.GameAdapters/Patches/GenericStateMenuPatch.cs` - Prevents menu stutter during reserve mode
+- `src/Mod.GameAdapters/Patches/AbandonArmyBlockPatch.cs` - Removes “Abandon army” options while enlisted
 
 ---
 
@@ -78,6 +80,7 @@ Keep enlisted players from accidentally entering encounters that would break mil
 3. Player party kept in same army/attachment so vanilla encounter stack automatically collects it
 4. `JoinEncounterAutoSelectPatch` intercepts "join_encounter" menu and automatically joins battle on lord's side
 5. Player sees standard encounter menu (Attack/Send Troops/Wait) instead of "Help X's Party / Don't get involved"
+6. `AbandonArmyBlockPatch` hides native “Abandon army” options while enlisted (no change when not enlisted)
 6. Player participates in battle
 7. If the player is a prisoner or capture cleanup is queued, battle handling is skipped to let native captivity finish (prevents crash when captors are defeated by friendlies).
 

--- a/src/Features/Enlistment/Behaviors/EnlistmentBehavior.cs
+++ b/src/Features/Enlistment/Behaviors/EnlistmentBehavior.cs
@@ -614,6 +614,10 @@ namespace Enlisted.Features.Enlistment.Behaviors
                 ModLogger.Info("SaveLoad",
                     $"Loading enlistment state - Lord: {_enlistedLord?.Name?.ToString() ?? "null"}, Tier: {_enlistmentTier}, XP: {_enlistmentXP}, OnLeave: {_isOnLeave}, GracePeriod: {IsInDesertionGracePeriod}");
                 ValidateLoadedState();
+                
+                // Clean up any duplicate hero entries in rosters (can occur after escape from captivity)
+                DeduplicateRosterHeroes();
+                
                 ModLogger.Info("SaveLoad", "Enlistment state validated and restored");
 
                 // Sync activation based on loaded state
@@ -2534,6 +2538,103 @@ namespace Enlisted.Features.Enlistment.Behaviors
             }
 
             ModLogger.Info("SaveLoad", $"Validated enlistment state - Tier: {_enlistmentTier}, XP: {_enlistmentXP}");
+        }
+
+        /// <summary>
+        ///     Removes duplicate hero entries from player's roster that can occur after escape from captivity.
+        ///     Also cleans up stale references to player companions in other parties (e.g., lord's party).
+        /// </summary>
+        private void DeduplicateRosterHeroes()
+        {
+            try
+            {
+                var main = MobileParty.MainParty;
+                if (main == null)
+                {
+                    return;
+                }
+
+                var mainRoster = main.MemberRoster;
+                var duplicatesRemoved = 0;
+                var staleRefsRemoved = 0;
+
+                // Track heroes we've seen in main roster to detect duplicates
+                var seenHeroes = new HashSet<CharacterObject>();
+                var heroesToRemove = new List<(CharacterObject character, int excess)>();
+
+                foreach (var troop in mainRoster.GetTroopRoster())
+                {
+                    if (!troop.Character.IsHero)
+                    {
+                        continue;
+                    }
+
+                    // Heroes should only appear once in roster (count = 1)
+                    if (troop.Number > 1)
+                    {
+                        heroesToRemove.Add((troop.Character, troop.Number - 1));
+                    }
+                    else if (seenHeroes.Contains(troop.Character))
+                    {
+                        // Duplicate entry - shouldn't happen but clean up
+                        heroesToRemove.Add((troop.Character, troop.Number));
+                    }
+                    else
+                    {
+                        seenHeroes.Add(troop.Character);
+                    }
+                }
+
+                // Remove duplicate hero entries
+                foreach (var (character, excess) in heroesToRemove)
+                {
+                    mainRoster.AddToCounts(character, -excess, false, 0, 0, true, -1);
+                    duplicatesRemoved += excess;
+                    ModLogger.Warn("SaveLoad", $"Removed {excess} duplicate entry for hero {character.Name}");
+                }
+
+                // Clean up stale companion references in lord's party (if enlisted)
+                if (_enlistedLord?.PartyBelongedTo != null)
+                {
+                    var lordRoster = _enlistedLord.PartyBelongedTo.MemberRoster;
+                    var staleCompanions = new List<TroopRosterElement>();
+
+                    foreach (var troop in lordRoster.GetTroopRoster())
+                    {
+                        if (!troop.Character.IsHero || troop.Character == CharacterObject.PlayerCharacter)
+                        {
+                            continue;
+                        }
+
+                        var hero = troop.Character.HeroObject;
+                        if (hero != null && hero.Clan == Clan.PlayerClan)
+                        {
+                            // Companion is in lord's party - check if also in player's party (stale ref)
+                            if (mainRoster.GetTroopCount(troop.Character) > 0)
+                            {
+                                staleCompanions.Add(troop);
+                            }
+                        }
+                    }
+
+                    foreach (var stale in staleCompanions)
+                    {
+                        lordRoster.AddToCounts(stale.Character, -stale.Number, false, 0, 0, true, -1);
+                        staleRefsRemoved++;
+                        ModLogger.Warn("SaveLoad", $"Removed stale companion ref {stale.Character.Name} from lord's party");
+                    }
+                }
+
+                if (duplicatesRemoved > 0 || staleRefsRemoved > 0)
+                {
+                    ModLogger.Info("SaveLoad",
+                        $"Roster cleanup: removed {duplicatesRemoved} duplicates, {staleRefsRemoved} stale refs");
+                }
+            }
+            catch (Exception ex)
+            {
+                ModLogger.Error("SaveLoad", $"Error during roster deduplication: {ex.Message}");
+            }
         }
 
         /// <summary>
@@ -6077,6 +6178,7 @@ namespace Enlisted.Features.Enlistment.Behaviors
         /// <summary>
         ///     Restore companions to player party on retirement (regular troops stay with lord).
         ///     Companions should be available for the player again after service ends.
+        ///     Deduplicates against existing roster and cleans stale refs from lord party.
         /// </summary>
         private void RestoreCompanionsToPlayer()
         {
@@ -6085,52 +6187,79 @@ namespace Enlisted.Features.Enlistment.Behaviors
                 var main = MobileParty.MainParty;
                 var lordParty = _enlistedLord?.PartyBelongedTo;
 
-                if (main == null || lordParty == null)
+                if (main == null)
                 {
+                    ModLogger.Warn("Enlistment", "RestoreCompanionsToPlayer skipped - main party missing");
                     return;
                 }
 
-                var companionsRestored = 0;
+                if (lordParty == null)
+                {
+                    ModLogger.Warn("Enlistment", "RestoreCompanionsToPlayer skipped - lord party missing");
+                    return;
+                }
+
+                var mainRoster = main.MemberRoster;
+                var lordRoster = lordParty.MemberRoster;
                 var companionsToRestore = new List<TroopRosterElement>();
+                var staleRefsToRemove = new List<TroopRosterElement>();
 
                 // Find player's companions in lord's party
-                foreach (var troop in lordParty.MemberRoster.GetTroopRoster())
+                foreach (var troop in lordRoster.GetTroopRoster())
                 {
-                    // Only restore hero companions, not regular troops
-                    if (troop.Character.IsHero && troop.Character != CharacterObject.PlayerCharacter)
+                    if (!troop.Character.IsHero || troop.Character == CharacterObject.PlayerCharacter)
                     {
-                        // Check if this companion belongs to player's clan
-                        var hero = troop.Character.HeroObject;
-                        if (hero != null && hero.Clan == Clan.PlayerClan)
-                        {
-                            companionsToRestore.Add(troop);
-                            companionsRestored += troop.Number;
-                        }
+                        continue;
+                    }
+
+                    var hero = troop.Character.HeroObject;
+                    if (hero == null || hero.Clan != Clan.PlayerClan)
+                    {
+                        continue;
+                    }
+
+                    // Check if companion already in player's roster
+                    if (mainRoster.GetTroopCount(troop.Character) > 0)
+                    {
+                        // Stale reference - companion escaped and is already with player
+                        staleRefsToRemove.Add(troop);
+                    }
+                    else
+                    {
+                        // Need to restore this companion to player
+                        companionsToRestore.Add(troop);
                     }
                 }
 
-                // Transfer companions back to player using verified API pattern
-                foreach (var companion in companionsToRestore)
+                // Remove stale references from lord's party (companion already with player)
+                foreach (var stale in staleRefsToRemove)
                 {
-                    // Remove from lord's party
-                    lordParty.MemberRoster.AddToCounts(companion.Character, -1 * companion.Number, false, 0, 0, true,
-                        -1);
-                    // Add back to player party
-                    main.MemberRoster.AddToCounts(companion.Character, companion.Number, false, 0, 0, true, -1);
+                    lordRoster.AddToCounts(stale.Character, -stale.Number, false, 0, 0, true, -1);
+                    ModLogger.Info("Enlistment", $"Cleaned stale ref for {stale.Character.Name} from lord's party");
                 }
 
-                if (companionsRestored > 0)
+                // Transfer companions that need restoration
+                foreach (var companion in companionsToRestore)
+                {
+                    lordRoster.AddToCounts(companion.Character, -companion.Number, false, 0, 0, true, -1);
+                    mainRoster.AddToCounts(companion.Character, companion.Number, false, 0, 0, true, -1);
+                }
+
+                if (companionsToRestore.Count > 0)
                 {
                     var message =
                         new TextObject("{=enlist_companions_rejoined}Your {COMPANION_COUNT} companions have rejoined your party upon retirement.");
-                    message.SetTextVariable("COMPANION_COUNT", companionsRestored.ToString());
+                    message.SetTextVariable("COMPANION_COUNT", companionsToRestore.Count.ToString());
                     InformationManager.DisplayMessage(new InformationMessage(message.ToString()));
 
                     ModLogger.Info("Enlistment",
-                        $"Restored {companionsRestored} companions to player party on retirement");
+                        $"Restored {companionsToRestore.Count} companions to player party (cleaned {staleRefsToRemove.Count} stale refs)");
                 }
-
-                // Note: Regular troops stay with the lord as they've become part of the military unit
+                else if (staleRefsToRemove.Count > 0)
+                {
+                    ModLogger.Info("Enlistment",
+                        $"Cleaned {staleRefsToRemove.Count} stale companion refs from lord's party (companions already with player)");
+                }
             }
             catch (Exception ex)
             {
@@ -7318,6 +7447,12 @@ namespace Enlisted.Features.Enlistment.Behaviors
             }
 
             ModLogger.Info("EventSafety", "Finalizing deferred capture cleanup for player");
+
+            // If the lord party vanished (captor destroyed/captured), companion restore will skip safely.
+            if (_enlistedLord?.PartyBelongedTo == null)
+            {
+                ModLogger.Warn("EventSafety", "Capture cleanup: lord party missing, companion restore may be skipped");
+            }
 
             if (kingdom != null)
             {

--- a/src/Features/Equipment/Behaviors/QuartermasterManager.cs
+++ b/src/Features/Equipment/Behaviors/QuartermasterManager.cs
@@ -38,6 +38,11 @@ namespace Enlisted.Features.Equipment.Behaviors
         private Dictionary<string, CharacterObject> _currentTroopCache;
         [System.Diagnostics.CodeAnalysis.SuppressMessage("ReSharper", "UnusedMember.Local", Justification = "May be used for future cache invalidation")]
         private CampaignTime _lastCacheUpdate = CampaignTime.Zero;
+        private static readonly HashSet<string> NonReturnableQuestItemIds =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "dragon_banner" // Main quest banner item should never be returned
+            };
 
         // Quartermaster state
         private CharacterObject _selectedTroop;
@@ -928,6 +933,12 @@ namespace Enlisted.Features.Equipment.Behaviors
         private static bool IsReturnableItem(ItemObject item)
         {
             if (item == null)
+            {
+                return false;
+            }
+
+            // Never allow quest-critical items (e.g., Dragon Banner) to be returned
+            if (item.IsQuestItem || NonReturnableQuestItemIds.Contains(item.StringId))
             {
                 return false;
             }

--- a/src/Features/Equipment/Behaviors/QuartermasterManager.cs
+++ b/src/Features/Equipment/Behaviors/QuartermasterManager.cs
@@ -938,7 +938,7 @@ namespace Enlisted.Features.Equipment.Behaviors
             }
 
             // Never allow quest-critical items (e.g., Dragon Banner) to be returned
-            if (item.IsQuestItem || NonReturnableQuestItemIds.Contains(item.StringId))
+            if (NonReturnableQuestItemIds.Contains(item.StringId))
             {
                 return false;
             }

--- a/src/Features/Equipment/Behaviors/QuartermasterManager.cs
+++ b/src/Features/Equipment/Behaviors/QuartermasterManager.cs
@@ -862,6 +862,13 @@ namespace Enlisted.Features.Equipment.Behaviors
                     return;
                 }
 
+                // Only allow items that were issued by the quartermaster
+                var wasIssued = TroopSelectionManager.Instance?.IsIssuedItem(item.StringId) == true;
+                if (!wasIssued)
+                {
+                    return;
+                }
+
                 var total = GetPlayerItemCount(hero, item.StringId);
                 if (total > 0)
                 {
@@ -988,6 +995,7 @@ namespace Enlisted.Features.Equipment.Behaviors
 
                 var removed = TryReturnSingleItem(item);
                 var remaining = GetPlayerItemCount(Hero.MainHero, item.StringId);
+            var wasIssued = TroopSelectionManager.Instance?.IsIssuedItem(item.StringId) == true;
 
                 var message = removed
                     ? new TextObject("{=qm_return_success}Returned {ITEM_NAME} to the armory.")
@@ -997,7 +1005,13 @@ namespace Enlisted.Features.Equipment.Behaviors
                 InformationManager.DisplayMessage(new InformationMessage(message.ToString(), Colors.Yellow));
 
                 ModLogger.Info("Quartermaster",
-                    $"Return action: {item.Name}; removed={(removed ? "yes" : "no")}; remaining={remaining}");
+                $"Return action: {item.Name}; removed={(removed ? "yes" : "no")}; remaining={remaining}; issued={wasIssued}");
+
+            // Track issued-item returns for diagnostics
+            if (removed && wasIssued)
+            {
+                ModLogger.IncrementSummary("quartermaster_returns", 1, 0);
+            }
 
                 // Refresh options after removal
                 _returnOptions.Clear();

--- a/src/Features/Equipment/Behaviors/TroopSelectionManager.cs
+++ b/src/Features/Equipment/Behaviors/TroopSelectionManager.cs
@@ -835,6 +835,29 @@ namespace Enlisted.Features.Equipment.Behaviors
         }
 
         /// <summary>
+        /// Determine if an item (by stringId) is currently tracked as issued.
+        /// Used to filter quartermaster returns so only issued items are returnable.
+        /// </summary>
+        public bool IsIssuedItem(string itemStringId)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(itemStringId) || _issuedEquipment.Count == 0)
+                {
+                    return false;
+                }
+
+                return _issuedEquipment.Values.Any(v =>
+                    v != null && v.ItemStringId == itemStringId);
+            }
+            catch (Exception ex)
+            {
+                ModLogger.Error("TroopSelection", $"Error checking issued item: {ex.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Mark one issued item as returned, removing it from accountability tracking.
         /// Matches by ItemStringId; removes a single record.
         /// </summary>

--- a/src/Mod.Core/Logging/SessionDiagnostics.cs
+++ b/src/Mod.Core/Logging/SessionDiagnostics.cs
@@ -13,7 +13,7 @@ namespace Enlisted.Mod.Core.Logging
         /// <summary>
         ///     Mod version for diagnostics. Update this when releasing new versions.
         /// </summary>
-        public const string ModVersion = "0.5.3";
+        public const string ModVersion = "0.5.4";
 
         public const string TargetGameVersion = "1.3.9";
         private static bool _hasLoggedStartup;

--- a/src/Mod.Entry/SubModule.cs
+++ b/src/Mod.Entry/SubModule.cs
@@ -173,6 +173,7 @@ namespace Enlisted.Mod.Entry
                     _ = typeof(IncidentsSuppressionPatch);
                     _ = typeof(InfluenceMessageSuppressionPatch);
                     _ = typeof(PlayerIsAtSeaTagCrashFix);
+                    _ = typeof(EndCaptivityCleanupPatch);
                     _ = nameof(ArmyDispersedMenuPatch.Prefix);
                     _ = nameof(JoinEncounterAutoSelectPatch.Prefix);
                     _ = nameof(EncounterSuppressionPatch.Prefix);

--- a/src/Mod.GameAdapters/Patches/AbandonArmyBlockPatch.cs
+++ b/src/Mod.GameAdapters/Patches/AbandonArmyBlockPatch.cs
@@ -1,0 +1,52 @@
+using Enlisted.Features.Enlistment.Behaviors;
+using Enlisted.Mod.Core.Logging;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem.GameMenus;
+
+namespace Enlisted.Mod.GameAdapters.Patches
+{
+    /// <summary>
+    /// Prevents enlisted soldiers from seeing the native "Abandon army" options
+    /// in encounter-related menus. When enlisted, we short-circuit the native
+    /// on_condition callbacks so the option is hidden entirely.
+    /// </summary>
+    [HarmonyPatch]
+    internal static class AbandonArmyBlockPatch
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(TaleWorlds.CampaignSystem.CampaignBehaviors.EncounterGameMenuBehavior),
+            "game_menu_join_encounter_abandon_army_on_condition")]
+        private static bool HideJoinEncounterAbandon(MenuCallbackArgs args, ref bool __result)
+        {
+            if (IsPlayerEnlisted())
+            {
+                __result = false; // option is removed from the menu
+                ModLogger.Debug("Encounter", "Hid join_encounter abandon army for enlisted player");
+                return false;
+            }
+
+            return true; // fall through to native condition
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(TaleWorlds.CampaignSystem.CampaignBehaviors.EncounterGameMenuBehavior),
+            "game_menu_encounter_abandon_army_on_condition")]
+        private static bool HideEncounterAbandon(MenuCallbackArgs args, ref bool __result)
+        {
+            if (IsPlayerEnlisted())
+            {
+                __result = false; // option is removed from the menu
+                ModLogger.Debug("Encounter", "Hid encounter abandon army for enlisted player");
+                return false;
+            }
+
+            return true; // fall through to native condition
+        }
+
+        private static bool IsPlayerEnlisted()
+        {
+            return EnlistmentBehavior.Instance?.IsEnlisted == true;
+        }
+    }
+}
+

--- a/src/Mod.GameAdapters/Patches/EndCaptivityCleanupPatch.cs
+++ b/src/Mod.GameAdapters/Patches/EndCaptivityCleanupPatch.cs
@@ -1,0 +1,91 @@
+using Enlisted.Mod.Core.Logging;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Settlements;
+
+// ReSharper disable UnusedType.Global
+// ReSharper disable UnusedMember.Local
+// ReSharper disable InconsistentNaming
+namespace Enlisted.Mod.GameAdapters.Patches
+{
+    /// <summary>
+    /// Fixes vanilla issue where player isn't removed from captor's prison roster when
+    /// captor party is inactive (e.g., captor was defeated/captured).
+    /// This prevents hero duplication after escaping captivity.
+    /// </summary>
+    [HarmonyPatch(typeof(PlayerCaptivity), nameof(PlayerCaptivity.EndCaptivity))]
+    public static class EndCaptivityCleanupPatch
+    {
+        /// <summary>
+        /// After vanilla EndCaptivity runs, ensure player is removed from all prison rosters.
+        /// Vanilla only removes from captor if captor.IsActive, leaving stale refs when captor is inactive.
+        /// </summary>
+        private static void Postfix()
+        {
+            try
+            {
+                // Skip during campaign initialization (character creation, rare edge cases)
+                if (Campaign.Current == null)
+                {
+                    return;
+                }
+
+                var playerChar = Hero.MainHero?.CharacterObject;
+                if (playerChar == null)
+                {
+                    return;
+                }
+
+                var removed = 0;
+
+                // Check all mobile parties for stale prison roster entries
+                foreach (var party in MobileParty.All)
+                {
+                    if (party?.PrisonRoster == null)
+                    {
+                        continue;
+                    }
+
+                    var count = party.PrisonRoster.GetTroopCount(playerChar);
+                    if (count > 0)
+                    {
+                        party.PrisonRoster.AddToCounts(playerChar, -count);
+                        removed++;
+                        ModLogger.Info("CaptivityFix",
+                            $"Removed player from stale prison roster: {party.Name?.ToString() ?? party.StringId}");
+                    }
+                }
+
+                // Also check settlement prison rosters
+                foreach (var settlement in Settlement.All)
+                {
+                    if (settlement?.Party?.PrisonRoster == null)
+                    {
+                        continue;
+                    }
+
+                    var count = settlement.Party.PrisonRoster.GetTroopCount(playerChar);
+                    if (count > 0)
+                    {
+                        settlement.Party.PrisonRoster.AddToCounts(playerChar, -count);
+                        removed++;
+                        ModLogger.Info("CaptivityFix",
+                            $"Removed player from stale settlement prison: {settlement.Name}");
+                    }
+                }
+
+                if (removed > 0)
+                {
+                    ModLogger.Info("CaptivityFix",
+                        $"Cleaned {removed} stale prison roster entries for player after escape");
+                }
+            }
+            catch (System.Exception ex)
+            {
+                ModLogger.Error("CaptivityFix", $"Error cleaning prison rosters: {ex.Message}");
+            }
+        }
+    }
+}
+

--- a/tools/workshop/WORKSHOP_UPLOAD.md
+++ b/tools/workshop/WORKSHOP_UPLOAD.md
@@ -150,6 +150,6 @@ tools/workshop/
 |-------|-------|
 | AppID | 261550 |
 | Mod Name | Enlisted |
-| Version | v0.5.3 |
+| Version | v0.5.4 |
 | Visibility | 0=Public, 1=Friends, 2=Hidden |
 

--- a/tools/workshop/workshop_upload.vdf
+++ b/tools/workshop/workshop_upload.vdf
@@ -52,6 +52,6 @@ Harmony → Native → ... → Enlisted"
     }
     
     // Optional: Change notes for updates
-    "changenote" "Update v0.5.3"
+    "changenote" "Update v0.5.4"
 }
 


### PR DESCRIPTION
## Summary
- Hide the native "Abandon army" options for enlisted players via AbandonArmyBlockPatch (join_encounter and encounter menus).
- Wire the patch into the project and update encounter-safety docs.
- Bump mod version to v0.5.4 across SubModule, configs, assembly info, diagnostics, and workshop metadata.

## Testing
- dotnet build -c "Enlisted RETAIL" /p:Platform=x64
- In-game: enlisted encounter shows Attack/Leave/Wait without Abandon army (requires closing Bannerlord launcher to copy DLL before testing).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Hides native “Abandon army” options while enlisted, adds post-captivity prison roster cleanup, refines battle auto-join and settlement menu behavior, tightens quartermaster returns, and bumps version to v0.5.4.
> 
> - **Gameplay Patches**
>   - Add `src/Mod.GameAdapters/Patches/AbandonArmyBlockPatch.cs` to hide native “Abandon army” options when enlisted.
>   - Add `src/Mod.GameAdapters/Patches/EndCaptivityCleanupPatch.cs` to remove stale player entries from prison rosters after captivity ends.
> - **Enlistment/Battle Flow** (`src/Features/Enlistment/Behaviors/EnlistmentBehavior.cs`)
>   - Implement immediate battle join guard (`ForceImmediateBattleJoin`) to prevent instant auto-resolve skirmishes.
>   - On load: deduplicate hero roster, clean stale companion refs, and auto-activate enlisted menu.
>   - Settlement handling: allow peaceful town/castle encounters; keep enlisted menu active when safe.
>   - Harden capture/grace cleanup and post-battle flow; minor visual refresh and state safety fixes.
> - **UI/Menus** (`src/Features/Interface/Behaviors/EnlistedMenuBehavior.cs`)
>   - Permit enlisted menu during settlement encounters; add reliable “Visit Town/Castle” availability.
>   - Safer overrides for `army_wait`/`army_wait_at_settlement` respecting sieges/battles.
> - **Quartermaster/Equipment**
>   - `QuartermasterManager`: Only return items tracked as issued; block quest items (e.g., `dragon_banner`); add return diagnostics.
>   - `TroopSelectionManager`: expose `IsIssuedItem` for return filtering.
> - **Docs & Versioning**
>   - Update docs: encounter-safety to include abandon-army suppression and settlement behavior.
>   - Bump to `v0.5.4` in `SubModule.xml`, `AssemblyInfo.cs`, `SessionDiagnostics.cs`, configs, and workshop files.
> - **Project Wiring**
>   - Include new patches in `Enlisted.csproj` and reference `EndCaptivityCleanupPatch` in startup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cceef94564eac60a53f15b21f789fc314b77fa24. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->