### PR TITLE
Matching Soldier rep with description

### DIFF
--- a/src/Features/Escalation/EscalationState.cs
+++ b/src/Features/Escalation/EscalationState.cs
@@ -10,7 +10,7 @@ namespace Enlisted.Features.Escalation
     /// Ranges (per docs/Features/Core/core-gameplay.md):
     /// - Scrutiny: 0–10
     /// - Discipline: 0–10
-    /// - Soldier reputation: -50..+50 (renamed from LanceReputation)
+    /// - Soldier reputation: -50..+100 (renamed from LanceReputation)
     /// - Lord reputation: 0–100 (NEW)
     /// - Officer reputation: 0–100 (NEW)
     /// - Medical risk: 0–5
@@ -25,7 +25,7 @@ namespace Enlisted.Features.Escalation
         public const int DisciplineMin = 0;
         public const int DisciplineMax = 10;
         public const int SoldierReputationMin = -50;
-        public const int SoldierReputationMax = 50;
+        public const int SoldierReputationMax = 100;
         public const int LordReputationMin = 0;
         public const int LordReputationMax = 100;
         public const int OfficerReputationMin = 0;


### PR DESCRIPTION
I've read the description on github and it's say "soldier reputation (-50 to +100): popularity among rank-and-file troops"

I've match the code to the description.

# Summary

Describe the change and the problem it solves:

I've changed the summary description for soldier rep and the max value for it too.
It solve the stucking problem to rank up T7 to T8.


# Rationale

Why is this change needed?

Be stuck at T7 is a problem that need to be fix

# Testing

- Steps to test in-game
- Screenshots/logs (if applicable)

No test in game because I don't know how to do that... I would be glad to do it if you can explain to me how to do that.

# Checklist
- [ ] Follows .editorconfig style
- [ ] Keeps DECOMPILE and vendor sources out of the repo
- [ ] Builds against local Bannerlord DLLs
- [ ] Updated docs (README/CHANGELOG) if needed
